### PR TITLE
fix(editor-gui): use the bundled certifi when OpenSSL has no trust store

### DIFF
--- a/apps/editor-gui/src/editor_gui/certs.py
+++ b/apps/editor-gui/src/editor_gui/certs.py
@@ -1,0 +1,51 @@
+"""Make TLS trust work in the packaged desktop app.
+
+PyInstaller bundles the OpenSSL that Python was built against, and that OpenSSL carries the *build
+machine's* trust-store location compiled in — for the macOS build,
+``/Library/Frameworks/Python.framework/Versions/3.13/etc/openssl/cert.pem``. That path does not
+exist on a user's machine, so ``ssl.create_default_context()`` loads zero CA certificates and every
+``urllib`` HTTPS request fails with::
+
+    [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate
+
+``httpx`` call sites (the documentation downloader) are unaffected because httpx uses :mod:`certifi`
+explicitly, which is why only the ``urllib`` ones broke: the MyKnx login, the update check and the
+online catalog.
+
+The app already ships a ``certifi`` bundle, so the fix is to point OpenSSL at it when — and only
+when — it has nothing else to work with.
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+from pathlib import Path
+
+
+def ensure_ca_bundle() -> str | None:
+    """Point OpenSSL at ``certifi`` when it has no usable trust store of its own.
+
+    Returns the path installed into ``SSL_CERT_FILE``, or ``None`` when nothing needed changing
+    (the normal case when running from source on a machine with system certificates).
+
+    Call once, before the first HTTPS request. Cheap and safe to call unconditionally.
+    """
+    # `cafile`/`capath` are None unless the location actually exists on disk, and both already
+    # account for the SSL_CERT_FILE / SSL_CERT_DIR overrides — so this one check covers a working
+    # system store *and* an explicit override the user or a distro packager set deliberately.
+    paths = ssl.get_default_verify_paths()
+    if paths.cafile or paths.capath:
+        return None
+
+    try:
+        import certifi
+    except ImportError:  # not installed (source checkout without the GUI extras)
+        return None
+
+    bundle = certifi.where()
+    if not Path(bundle).is_file():
+        return None
+
+    os.environ["SSL_CERT_FILE"] = bundle
+    return bundle

--- a/apps/editor-gui/src/editor_gui/main.py
+++ b/apps/editor-gui/src/editor_gui/main.py
@@ -21,6 +21,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from xknxproject.exceptions import InvalidPasswordException, XknxProjectException
 
 from editor_gui import __version__
+from editor_gui.certs import ensure_ca_bundle
 from editor_gui.concurrency import MainThreadExecutor
 from editor_gui.master_data import MasterDataInfo, load_master, master_xml_bytes
 from editor_gui.plugins.base import API_VERSION, Logger, PanelDefinition, PluginAPI
@@ -2057,6 +2058,10 @@ def _detect_locale() -> str:
 
 def main() -> None:
     import sys
+
+    # Before anything can reach the network: the packaged app's OpenSSL points at a trust store
+    # that only exists on the build machine, so fall back to the bundled certifi (see certs.py).
+    ensure_ca_bundle()
 
     if "--profile" in sys.argv:
         import cProfile

--- a/apps/editor-gui/src/editor_gui/tests/test_certs.py
+++ b/apps/editor-gui/src/editor_gui/tests/test_certs.py
@@ -1,0 +1,79 @@
+"""Tests for the packaged-app CA bundle fallback."""
+
+from __future__ import annotations
+
+import os
+import ssl
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+from editor_gui import certs
+
+
+class _FakeCertifi:
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    def where(self) -> str:
+        return self._path
+
+
+class _Paths(NamedTuple):
+    """Stand-in for a ``get_default_verify_paths()`` result.
+
+    Only ``cafile``/``capath`` matter here. At runtime both are ``None`` when the location does not
+    exist on disk — the packaged-app situation — even though typeshed declares them as ``str``.
+    """
+
+    cafile: str | None
+    capath: str | None
+
+
+def _paths(cafile: str | None, capath: str | None) -> _Paths:
+    return _Paths(cafile=cafile, capath=capath)
+
+
+def test_installs_certifi_when_openssl_has_no_trust_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The packaged-app case: OpenSSL's compiled-in paths do not exist on the user's machine."""
+    bundle = tmp_path / "cacert.pem"
+    bundle.write_text("-----BEGIN CERTIFICATE-----\n", encoding="utf-8")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setattr(ssl, "get_default_verify_paths", lambda: _paths(None, None))
+    monkeypatch.setitem(sys.modules, "certifi", _FakeCertifi(str(bundle)))
+
+    assert certs.ensure_ca_bundle() == str(bundle)
+    assert os.environ["SSL_CERT_FILE"] == str(bundle)
+
+
+def test_leaves_a_working_system_store_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ssl, "get_default_verify_paths", lambda: _paths("/etc/ssl/cert.pem", None)
+    )
+    assert certs.ensure_ca_bundle() is None
+
+
+def test_respects_an_existing_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An SSL_CERT_FILE the user or packager set is reflected in ``cafile`` — never overwrite it."""
+    monkeypatch.setattr(
+        ssl, "get_default_verify_paths", lambda: _paths("/custom/ca.pem", None)
+    )
+    assert certs.ensure_ca_bundle() is None
+
+
+def test_capath_alone_is_enough(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ssl, "get_default_verify_paths", lambda: _paths(None, "/etc/ssl/certs")
+    )
+    assert certs.ensure_ca_bundle() is None
+
+
+def test_missing_certifi_is_not_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A source checkout without certifi must not crash at startup."""
+    monkeypatch.setattr(ssl, "get_default_verify_paths", lambda: _paths(None, None))
+    monkeypatch.setitem(sys.modules, "certifi", None)  # makes `import certifi` raise
+    assert certs.ensure_ca_bundle() is None


### PR DESCRIPTION
## The bug

The released macOS app cannot make any `urllib` HTTPS request. Signing an export fails at the MyKnx login with:

```
Login failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:1032)>
```

## Cause

PyInstaller bundles the OpenSSL that Python was built against, and that OpenSSL carries the **build machine's** trust-store location compiled in. In `XKNX-Editor-macos.zip` (v0.1.0) it is:

```
/Library/Frameworks/Python.framework/Versions/3.13/etc/openssl/cert.pem
```

That path does not exist on a user's machine, so `ssl.create_default_context()` loads **zero** CA certificates and every verification fails.

The app *does* ship a good CA bundle at `Contents/Resources/certifi/cacert.pem` (121 roots) — `urllib` just never looks there. `httpx` does, because it uses `certifi` explicitly. That asymmetry is the tell, and it matches the symptoms exactly:

| Call site | Client | Affected |
|---|---|---|
| `myknx_cert.py` — MyKnx login / project certificate | `urllib` | **yes** |
| `update_check.py` — release check | `urllib` | **yes** (silent: it catches every exception and returns `None`) |
| `online_catalog.py` — online catalog | `urllib` | **yes** |
| `mcp/tools/catalog.py` — documentation downloads | `httpx` | no |

## The fix

A small `certs.py`, called first thing in `main()`, that points OpenSSL at the bundled `certifi` file — but only when OpenSSL has nothing usable of its own.

`ssl.get_default_verify_paths()` already returns `cafile`/`capath` as `None` unless the location exists on disk, and it already accounts for the `SSL_CERT_FILE` / `SSL_CERT_DIR` overrides. So a single check covers both "the system store works" and "someone set an override deliberately", and neither is ever touched. A source checkout on a normal machine is a no-op.

Deliberately not done: pinning `SSL_CERT_FILE` in the `.spec`, which would override a user's system store, and shipping our own trust decisions to source installs that do not need them.

## Verification

Against the live endpoint with the trust store forced empty (`SSL_CERT_FILE`/`SSL_CERT_DIR` pointed at non-existent paths), in separate processes:

```
--- WITHOUT fix ---
  store: cafile=None capath=None
  RESULT: FAILED -> URLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed

--- WITH fix ---
  installed: .../certifi/cacert.pem
  store: cafile=set capath=None
  RESULT: TLS OK (server replied HTTP 404)
```

(404 is just the server rejecting a `GET` on the login endpoint — the handshake is what matters.)

Also confirmed on the actual v0.1.0 release build by injecting the same CA path via `LSEnvironment`, which made the MyKnx login work.

Five unit tests cover: the packaged-app case, a working system store, an explicit override, `capath`-only, and `certifi` missing. `pytest` (33 passed), `ruff check`, `ruff format --check` and `pyright` (0 errors) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4Vbcq3A6eQSywWqmHDfv8
